### PR TITLE
Don't fail when syntax entry is missing for closing parens

### DIFF
--- a/autopair.el
+++ b/autopair.el
@@ -412,7 +412,8 @@ syntax table and the local value of `autopair-extra-pairs'."
           (cond ((eq class (car (string-to-syntax "(")))
                  ;; syntax classes "opening parens" and "close parens"
                  (define-key map (string char) 'autopair-insert-opening)
-                 (define-key map (string pair) 'autopair-skip-close-maybe))
+                 (when pair
+                   (define-key map (string pair) 'autopair-skip-close-maybe)))
                 ((eq class (car (string-to-syntax "\"")))
                  ;; syntax class "string quote
                  (define-key map (string char) 'autopair-insert-or-skip-quote))


### PR DESCRIPTION
In the case of some buffers, e.g. `*urlparse-temp*`, there is no syntax entry for closing parens. When trying to enable `autopair-global-mode` with such buffers open, an error results due to autopair assuming there is such an entry. This commit prevents that error by binding 'autopair-skip-close-maybe only if such a syntax entry exists.

(This behavior was observed in Emacs 24.)
