### PR TITLE
Add autoload cookies

### DIFF
--- a/autopair.el
+++ b/autopair.el
@@ -331,6 +331,7 @@ For now, simply returns `last-command-event'"
 
 ;; minor mode and global mode
 ;;
+;;;###autoload
 (define-globalized-minor-mode autopair-global-mode autopair-mode autopair-on)
 
 (when (>= emacs-major-version 24)
@@ -369,6 +370,7 @@ We want this advice to only kick in the *second* call to
                    autopair-dont-activate)
     (autopair-mode 1))))
 
+;;;###autoload
 (define-minor-mode autopair-mode
   "Automagically pair braces and quotes like in TextMate."
   nil " pair" nil


### PR DESCRIPTION
I added autoload cookies to autopair-mode and autopair-global-mode.  This way I can automatically generate the (autoload) forms for autopair, and avoid loading autopair until I actually need it.

Thanks for autopair!
