### PR TITLE
js2-mode and javascript-mode report forward-sexp errors differently

### DIFF
--- a/autopair.el
+++ b/autopair.el
@@ -794,6 +794,7 @@ by this command. Then place point after the first, indented.\n\n"
                                  (setq prev-point (point))
                                  (forward-sexp))
                                t)
+                           (args-out-of-range t)
                            (error
                             ;; if `forward-sexp' (called by
                             ;; `autopair-forward') returned an error.


### PR DESCRIPTION
Seems to address Issue #21 for me. I think js2-mode is correctly reporting some bad syntax. I think change allows autopair to handle it gracefully. Hasn't seemed to have broken anything else (while working in js2-mode).
