### PR TITLE
autopair-global-mode will respect autopair-dont-activate

### DIFF
--- a/autopair.el
+++ b/autopair.el
@@ -394,13 +394,19 @@ been turned on before the major-mode hooks kicked in).
 
 We want this advice to only kick in the *second* call to
 `autopair-global-mode-enable-in-buffers'."
+
+Also it is possible for the user to bind `autopair-dont-activate' in
+a major mode hook, but `autopair-mode' will have already been turned on
+by the global mode, so we can disable it here to respect `autopair-dont-activate'."
     (dolist (buf autopair-global-mode-buffers)
       (when (buffer-live-p buf)
         (with-current-buffer buf
-          (when (and autopair-mode
-                     (not autopair--global-mode-emacs24-hack-flag))
-            (autopair--set-emulation-bindings)
-            (set (make-local-variable 'autopair--global-mode-emacs24-hack-flag) t)))))))
+          (when autopair-mode
+            (if (boundp 'autopair-dont-activate)
+                (autopair-mode -1)
+              (when (not autopair--global-mode-emacs24-hack-flag)
+                (autopair--set-emulation-bindings)
+                (set (make-local-variable 'autopair--global-mode-emacs24-hack-flag) t)))))))))
 
 (defun autopair-on ()
   (unless (or buffer-read-only


### PR DESCRIPTION
autopair-global-mode will respect autopair-dont-activate when set in a major-mode hook.

global minor modes will turn on before major modes are set, and you deal with that for turning on autopair mode, but not when autopair should not have been turned on in the first place. 

This will allow a user to set autopair-dont-activate in a major mode hook and the global mode will respect that by turning it off.

this is a known limitation of global minor modes: (taken from global minor mode docs)

```
If MODE's set-up depends on the major mode in effect when it was
enabled, then disabling and reenabling MODE should make MODE work
correctly with the current major mode.  This is important to
prevent problems with derived modes, that is, major modes that
call another major mode in their body.
```
